### PR TITLE
Updated spatie/laravel-permission version to 6.0 in composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "spatie/laravel-permission": "^5.1"
+        "spatie/laravel-permission": "^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
@shortcodes Laravel-permission version 6 has the necessary dependencies for Laravel 11 that I need.